### PR TITLE
Add a missing book recommendation from Grady Booch

### DIFF
--- a/2026_02_02.md
+++ b/2026_02_02.md
@@ -32,6 +32,7 @@ Some of the topics we hit on, in the order that we hit them (some LLM assistance
 ## Grady's Book Recommendations
 
 - [*The Sciences of the Artificial* — Herbert Simon](https://en.wikipedia.org/wiki/The_Sciences_of_the_Artificial)
+- [*Systemantics* — John Gall](https://en.wikipedia.org/wiki/Systemantics)
 - [*The Mythical Man-Month* — Fred Brooks](https://en.wikipedia.org/wiki/The_Mythical_Man-Month)
 - [*Refactoring* — Martin Fowler](https://martinfowler.com/books/refactoring.html)
 


### PR DESCRIPTION
It's visible in the transcript [here](https://oxide-and-friends.transistor.fm/episodes/software-engineering-past-present-and-future-with-grady-booch/transcript#t=52m25s).